### PR TITLE
Use String[] overload of Runtime.exec instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Apache Cordova Plugin to Execute Commands in Smartphone's Operating System Shell
 window.ShellExec.exec(cmd, callback)
 ```
 
+`cmd` can be either a single string or an array of string arguments.
+
 callback function will return a hash with two keys - `exitStatus` and `output`.
 
 Example:
@@ -35,9 +37,14 @@ cmd output: up time: 10 days, 05:16:51, idle time: 17 days, 01:22:57, sleep time
 
 If command execution fails (e.g. you enter wrong command), you receive exit status `100`.
 
-### Notes
+Example with root:
 
-* Currently plugin works properly only in user mode. Some [code tweaks](http://stackoverflow.com/a/6882295/4606227) are needed to run commands as root (I do not have a rooted Android phone to test it).
+```
+window.ShellExec.exec(['su', '-c', 'touch /sdcard/test.txt'], function(res){
+  console.log('exit status: ' + res.exitStatus)
+  console.log('cmd output: ' + res.output)
+})
+```
 
 ### How to Contribute
 

--- a/src/org/apache/cordova/plugin/ShellExec.java
+++ b/src/org/apache/cordova/plugin/ShellExec.java
@@ -18,7 +18,18 @@ public class ShellExec extends CordovaPlugin {
 public boolean execute(String action, JSONArray args, final CallbackContext callbackContext) throws JSONException {
 
         if (action.equals("exec")) {
-                final String cmd = (String) args.get(0);
+                String[] cmdArray;
+                try {
+                        JSONArray cmdJsonArray = args.getJSONArray(0);
+                        cmdArray = new String[cmdJsonArray.length()];
+                        for (int i=0; i<cmdJsonArray.length(); ++i) {
+                                cmdArray[i] = cmdJsonArray.getString(i);
+                        }
+
+                } catch (JSONException e) {
+                        cmdArray = new String[]{ args.getString(0) };
+                }
+                final String[] cmd = cmdArray;
                 cordova.getThreadPool().execute(new Runnable() {
                         public void run() {
                                 Process p;


### PR DESCRIPTION
This pull request allows the use of spaces in arguments to the command call by switching to the String[] overload of Runtime.exec(). As a side effect, root commands can be issued through an array like `['su', '-c', command]`.

`window.ShellExec.exec` still accepts a single string for `cmd`, but the whole string is treated as the command argument.